### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Rolf Leggewie <foss@rolf.leggewie.biz>
 Uploaders: Ikuya Awashiro <ikuya@oooug.jp>, Osamu Aoki <osamu@debian.org>
 Build-Depends: debhelper (>= 7.0.50~), libanthy-dev,
- scim (>= 1.4.6), libscim-dev (>= 1.4.14-2), autotools-dev, pkg-config,
+ scim, libscim-dev, autotools-dev, pkg-config,
  dh-autoreconf, libltdl-dev
 Standards-Version: 3.9.4
 Homepage: http://sourceforge.jp/projects/scim-imengine/


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/26/3e32a5ba9fe949031b7a9e5890df09f72aaaf6.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/41/4ef1cbf70866ef8c7c421534ac457db58476fa.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/da/7ac8dabcd7976e8384d046f1d38bb43ce5c9ee.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/90/9105adf178518346ae527926f56cbba04af61b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/cd/3ba9e323303d0af70ddecdd4de41addf62d05b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e1/a55f56c902dbc4a047bd1fbad3981f8862010a.debug

No differences were encountered between the control files of package \*\*scim-anthy\*\*
### Control files of package scim-anthy-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-909105adf178518346ae527926f56cbba04af61b cd3ba9e323303d0af70ddecdd4de41addf62d05b e1a55f56c902dbc4a047bd1fbad3981f8862010a-] {+263e32a5ba9fe949031b7a9e5890df09f72aaaf6 414ef1cbf70866ef8c7c421534ac457db58476fa da7ac8dabcd7976e8384d046f1d38bb43ce5c9ee+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/408a2452-319a-48d0-a517-10f23de3175f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/408a2452-319a-48d0-a517-10f23de3175f/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/scim-anthy/408a2452-319a-48d0-a517-10f23de3175f.